### PR TITLE
Remove redundant dispatch prior to initial roundtrip.

### DIFF
--- a/main.c
+++ b/main.c
@@ -138,7 +138,6 @@ int main(int argc, char *argv[]) {
 
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 
 	if (shm == NULL || compositor == NULL || xdg_wm_base == NULL) {


### PR DESCRIPTION
The `wl_display_dispatch` call is unnecessary here, since `wl_display_roundtrip` will dispatch internally.