### PR TITLE
build: fix cross-compilation with pkg-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-WAYLAND_FLAGS = $(shell pkg-config wayland-client --cflags --libs)
-WAYLAND_PROTOCOLS_DIR = $(shell pkg-config wayland-protocols --variable=pkgdatadir)
-WAYLAND_SCANNER = $(shell pkg-config --variable=wayland_scanner wayland-scanner)
 CFLAGS ?= -std=c11 -Wall -Wextra -Werror -Wno-unused-parameter -g
+PKG_CONFIG ?= pkg-config
+
+WAYLAND_FLAGS = $(shell $(PKG_CONFIG) wayland-client --cflags --libs)
+WAYLAND_PROTOCOLS_DIR = $(shell $(PKG_CONFIG) wayland-protocols --variable=pkgdatadir)
+WAYLAND_SCANNER = $(shell $(PKG_CONFIG) --variable=wayland_scanner wayland-scanner)
 
 XDG_SHELL_PROTOCOL = $(WAYLAND_PROTOCOLS_DIR)/stable/xdg-shell/xdg-shell.xml
 


### PR DESCRIPTION
Conventionally, when cross-compiling, PKG_CONFIG is set to the prefixed pkg-config wrapper for the platform being built for.