### PR TITLE
Don't use $PKG_CONFIG for wayland-scanner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 CFLAGS ?= -std=c11 -Wall -Wextra -Werror -Wno-unused-parameter -g
 PKG_CONFIG ?= pkg-config
 
+# Host deps
 WAYLAND_FLAGS = $(shell $(PKG_CONFIG) wayland-client --cflags --libs)
 WAYLAND_PROTOCOLS_DIR = $(shell $(PKG_CONFIG) wayland-protocols --variable=pkgdatadir)
-WAYLAND_SCANNER = $(shell $(PKG_CONFIG) --variable=wayland_scanner wayland-scanner)
+
+# Build deps
+WAYLAND_SCANNER = $(shell pkg-config --variable=wayland_scanner wayland-scanner)
 
 XDG_SHELL_PROTOCOL = $(WAYLAND_PROTOCOLS_DIR)/stable/xdg-shell/xdg-shell.xml
 


### PR DESCRIPTION
I made a mistake in the previous commit — $PKG_CONFIG should not be used to find wayland-scanner, because when cross-compiling that'll look for the cross-compiled wayland-scanner.  I missed this because I tested by compiling from glibc to musl on the same architecture, so I was testing a special case where my system could actually execute the cross-compiled wayland-scanner.